### PR TITLE
Rules are loaded but never added

### DIFF
--- a/ternip/rule_engine/rule_engine.py
+++ b/ternip/rule_engine/rule_engine.py
@@ -77,7 +77,7 @@ class rule_engine:
         
         Throws rule_load_error if a rule fails to load
         """
-        self._load_rule(filename)
+        self._rules.append(self._load_rule(filename))
         self._check_rule_consistency()
     
     def load_block(self, filename):
@@ -85,7 +85,7 @@ class rule_engine:
         Load a block of rules, then check for consistency
         Throws rule_load_errors if a rule fails to load
         """
-        self._load_block(filename)
+        self._rules.append(self._load_block(filename))
         self._check_rule_consistency()
     
     def _load_block(self, filename):


### PR DESCRIPTION
If one wanted to load only one rule (or ruleblock) using `load_rule` or `load_block` in `rule_engine.py`, the rules were loaded but never added to the local list of rules, making the call meaningless.
