### PR TITLE
tiny fix to normalization rule shortcut

### DIFF
--- a/ternip/rule_engine/normalisation_rule.py
+++ b/ternip/rule_engine/normalisation_rule.py
@@ -87,7 +87,7 @@ class NormalisationRule(rule.Rule):
         """
         # it would be nice to support named groups, but this'll do for now
         if exp is not None:
-            return compile(re.sub(r'\{#(\d)+\}', r'match.group(\1)', exp), self.id + ':' + type, 'eval')
+            return compile(re.sub(r'\{#(\d+)\}', r'match.group(\1)', exp), self.id + ':' + type, 'eval')
         else:
             return None
 


### PR DESCRIPTION
Shortcuts in python expressions to normalize can now have more than one digit. E.g. {#11}
